### PR TITLE
6/8/2021 - 12:03

### DIFF
--- a/pkg/compiler/parser/parser.go
+++ b/pkg/compiler/parser/parser.go
@@ -478,10 +478,6 @@ func (parser *Parser) parseClassStatement() (*ast.ClassStatement, *errors.Error)
 	if tokenizingError != nil {
 		return nil, tokenizingError
 	}
-	newLinesRemoveError = parser.removeNewLines()
-	if newLinesRemoveError != nil {
-		return nil, newLinesRemoveError
-	}
 	var bases []ast.Expression
 	var base ast.Node
 	var parsingError *errors.Error
@@ -491,7 +487,7 @@ func (parser *Parser) parseClassStatement() (*ast.ClassStatement, *errors.Error)
 			return nil, tokenizingError
 		}
 		for ; !parser.complete; {
-			newLinesRemoveError := parser.removeNewLines()
+			newLinesRemoveError = parser.removeNewLines()
 			if newLinesRemoveError != nil {
 				return nil, newLinesRemoveError
 			}

--- a/pkg/compiler/plasma/compile.go
+++ b/pkg/compiler/plasma/compile.go
@@ -329,7 +329,7 @@ func (c *Compiler) compileMethodInvocationExpression(methodInvocationExpression 
 		if argumentCompilationError != nil {
 			return nil, argumentCompilationError
 		}
-		result = append(result, argument...)
+		result = append(argument, result...)
 	}
 	function, functionCompilationError := c.compileExpression(methodInvocationExpression.Function)
 	if functionCompilationError != nil {
@@ -1201,9 +1201,14 @@ func (c *Compiler) compileClassBody(body []ast.Node) ([]vm.Code, *errors.Error) 
 }
 
 func (c *Compiler) compileInterfaceStatement(interfaceStatement *ast.InterfaceStatement) ([]vm.Code, *errors.Error) {
+	bases := make([]ast.Expression, len(interfaceStatement.Bases))
+	copy(bases, interfaceStatement.Bases)
+	for i, j := 0, len(bases)-1; i < j; i, j = i+1, j-1 {
+		bases[i], bases[j] = bases[j], bases[i]
+	}
 	result, basesCompilationError := c.compileExpression(
 		&ast.TupleExpression{
-			Values: interfaceStatement.Bases,
+			Values: bases,
 		},
 	)
 	if basesCompilationError != nil {
@@ -1232,9 +1237,14 @@ func (c *Compiler) compileInterfaceStatement(interfaceStatement *ast.InterfaceSt
 }
 
 func (c *Compiler) compileClassStatement(classStatement *ast.ClassStatement) ([]vm.Code, *errors.Error) {
+	bases := make([]ast.Expression, len(classStatement.Bases))
+	copy(bases, classStatement.Bases)
+	for i, j := 0, len(bases)-1; i < j; i, j = i+1, j-1 {
+		bases[i], bases[j] = bases[j], bases[i]
+	}
 	result, basesCompilationError := c.compileExpression(
 		&ast.TupleExpression{
-			Values: classStatement.Bases,
+			Values: bases,
 		},
 	)
 	if basesCompilationError != nil {

--- a/pkg/tests_samples/statements/class-statement/class.pm
+++ b/pkg/tests_samples/statements/class-statement/class.pm
@@ -10,5 +10,8 @@ module Business
     end
 end
 
+class Person
+end
+
 antonio = Business.Person("Antonio")
 println(antonio)

--- a/pkg/vm/object.go
+++ b/pkg/vm/object.go
@@ -186,13 +186,15 @@ func (o *Object) Implements(class *Type) bool {
 	return false
 }
 
-func (p *Plasma) constructSubClass(subClass *Type, object *Object) *Object {
+func (p *Plasma) constructSubClass(subClass *Type, object IObject) *Object {
 	for _, subSubClass := range subClass.subClasses {
+		object.SymbolTable().Parent = subSubClass.symbols.Parent
 		subSubClassConstructionError := p.constructSubClass(subSubClass, object)
 		if subSubClassConstructionError != nil {
 			return subSubClassConstructionError
 		}
 	}
+	object.SymbolTable().Parent = subClass.symbols.Parent
 	baseInitializationError := subClass.Constructor.Construct(p, object)
 	if baseInitializationError != nil {
 		return baseInitializationError
@@ -208,6 +210,7 @@ func (p *Plasma) ConstructObject(type_ *Type, parent *SymbolTable) (IObject, *Ob
 			return nil, subClassConstructionError
 		}
 	}
+	object.SymbolTable().Parent = parent
 	object.class = type_
 	baseInitializationError := type_.Constructor.Construct(p, object)
 	if baseInitializationError != nil {


### PR DESCRIPTION
- Fixed a bug where arguments where passed to functions in inverse order
- Fixed a bug where nested functions where asking directly to the parent caller symbol table, now they ask first to the parent namespace where of where they are defined
- Fixed the same bug of above but applying for classes and interfaces
- Now Inheritance give priority in name holding to the most left type in the bases