### PR TITLE
6/14/2021 - 7:07

### DIFF
--- a/pkg/vm/default.go
+++ b/pkg/vm/default.go
@@ -350,7 +350,7 @@ func (p *Plasma) setBuiltInSymbols() {
 									if _, ok := symbolName.(*String); !ok {
 										return nil, p.NewInvalidTypeError(symbolName.TypeName(), StringName)
 									}
-									self.SetString(fmt.Sprintf("cannot delete built-in symbol %s", symbolName.GetString()))
+									self.SetString(fmt.Sprintf("cannot assign/delete built-in symbol %s", symbolName.GetString()))
 									return p.NewNone(), nil
 								},
 							),

--- a/pkg/vm/plasma.go
+++ b/pkg/vm/plasma.go
@@ -108,6 +108,7 @@ func (p *Plasma) InitializeBytecode(bytecode *Bytecode) {
 			typeName:   ObjectName,
 			class:      nil,
 			subClasses: nil,
+			isBuiltIn:  true,
 			symbols:    p.builtInSymbolTable,
 		},
 	)


### PR DESCRIPTION
- Added built-in protection to the "__built_in__" variable.
- Improved the output message of "BuiltInSymbolProtectionError"